### PR TITLE
[TECH] Add continuous integration, using TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - "3.5"
+# command to install dependencies
+install:
+  - pip3 install -e .
+# command to run tests
+script:
+  - python3 -m eastereig


### PR DESCRIPTION
This branch stems from nennigb/master, and may be merged before #1 

Python version is 3.5, as explicitly specified in pip config file, so python entry may be removed in .travis.yml.