### PR TITLE
Update python version in CI script.

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -9,13 +9,17 @@ on:
       - README.md
   pull_request:
     branches: [ master ]
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # run at 02:01 on the 10th of each month
+    - cron:  '1 2 10 * *'     
 
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.8]        
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']   
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/setup.py
+++ b/setup.py
@@ -32,9 +32,9 @@ setuptools.setup(
     include_package_data=True,
     # we can use find_packages() to automatically discover all subpackages
     packages=setuptools.find_packages(),
-    install_requires=['numpy<=1.18.5', # max version for python3.5
-                      'scipy<=1.4.1',  # max version for python3.5
-                      'matplotlib<=3.0.1'], # max version for python3.5
+    install_requires=['numpy',
+                      'scipy',
+                      'matplotlib'],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",


### PR DESCRIPTION
Remove old python version and add a scheduled ci run. 
Remove hard-coded version of the dependencies (previously imposed to keep py3.5 compatibility)