### PR TITLE
Suspend petsc tests in CI.

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -45,22 +45,23 @@ jobs:
     - name: Run test without petsc
       run: |
         python -m eastereig
-    - name: Install petsc and their dependencies (support for parallel matrices)
-      run: |
-        sudo apt update --yes
-        # On 22.04 fails with mpich, but works on 20.04
-        # sudo apt-get install mpich libmpich-dev --yes
-        sudo apt install -y -q openmpi-bin libopenmpi-dev
-        pip install mpi4py
-        export PETSC_CONFIGURE_OPTIONS='--download-f2cblaslapack=1 --download-scalapack --download-mumps --with-scalar-type=complex'
-        pip install petsc petsc4py
-        pip install slepc slepc4py
-    - name: Run test with petsc
-      run: |
-        mpiexec --version
-        # No mpi call (check that it breaks nothing)
-        python -m eastereig
-        # Explicit mpi call
-        mpiexec -n 2 python eastereig/examples/WGimpedance_petsc.py
+#    # Since pip 23.1 trouble with pip installation of petsc4py        
+#    - name: Install petsc and their dependencies (support for parallel matrices)
+#      run: |
+#        sudo apt update --yes
+#        # On 22.04 fails with mpich, but works on 20.04
+#        # sudo apt-get install mpich libmpich-dev --yes
+#        sudo apt install -y -q openmpi-bin libopenmpi-dev
+#        pip install mpi4py
+#        export PETSC_CONFIGURE_OPTIONS='--download-f2cblaslapack=1 --download-scalapack --download-mumps --with-scalar-type=complex'
+#        pip install petsc petsc4py
+#        pip install slepc slepc4py
+#    - name: Run test with petsc
+#      run: |
+#        mpiexec --version
+#        # No mpi call (check that it breaks nothing)
+#        python -m eastereig
+#        # Explicit mpi call
+#        mpiexec -n 2 python eastereig/examples/WGimpedance_petsc.py
         
        


### PR DESCRIPTION
Since pip 23.1, `petsc4py` has trouble with pip installation. This PR just suspends it for a while.
In addition, we need to find a better way for testing petsc part  because `petsc` installation is quite long and should not be done at each run. Perhaps just for merging ?
