### PR TITLE
Fix scipy deprecated scipy.<numpy-func> removed in 1.12 release.

### DIFF
--- a/eastereig/eig.py
+++ b/eastereig/eig.py
@@ -652,7 +652,7 @@ class NumpyEig(AbstractEig):
         # Same matrix to factorize for all RHS
         Zer = np.zeros(shape=(1, 1), dtype=complex)
         Zerv = np.zeros(shape=(1,), dtype=complex)
-        Bord = sp.bmat([[L               , L1x.reshape(-1, 1)],
+        Bord = np.bmat([[L, L1x.reshape(-1, 1)],
                         [v.reshape(1, -1), Zer]])  # reshape is to avoid (n,) in bmat
 
         # if N > 1 loop for higher order terms

--- a/eastereig/eig.py
+++ b/eastereig/eig.py
@@ -185,7 +185,7 @@ class AbstractEig(ABC):
         # get Taylor coef in ascending order
         Df = dlda[0:n] / sp.special.factorial(np.arange(n))
         # polyval require higher degree first
-        tay = sp.polyval(Df[::-1], points - self.nu0)
+        tay = np.polyval(Df[::-1], points - self.nu0)
 
         return tay
 
@@ -323,8 +323,8 @@ class AbstractEig(ABC):
             dhTay = ep._dhTay
 
         # evaluate Taylor series
-        mapg = sp.polyval(dgTay[::-1], points - self.nu0)
-        maph = sp.polyval(dhTay[::-1], points - self.nu0)
+        mapg = np.polyval(dgTay[::-1], points - self.nu0)
+        maph = np.polyval(dhTay[::-1], points - self.nu0)
         ldap = 0.5*(mapg+np.sqrt(maph))
         ldam = 0.5*(mapg-np.sqrt(maph))
         return ldap, ldam

--- a/eastereig/examples/ThreeDoF.py
+++ b/eastereig/examples/ThreeDoF.py
@@ -68,12 +68,12 @@ Check eigenvalues
 True
 
 Get exceptional points location and check values
->>> EP1,EP2 = EPs
+>>> EP1, EP2 = EPs
 >>> EP1.locate()
 []
->>> res_EP2 = EP2.locate()[0]
+>>> res_EP2 = np.sort_complex(EP2.locate())[0]    # since cc
 >>> res_EP2
-(0.892616079814...+0.597704202996...j)
+(0.892616079814...-0.597704202996...j)
 
 Check eigenvalue reconstruction with Taylor, Padé, Puiseux and Analytic auxiliary functions
 >>> N = 6


### PR DESCRIPTION
In scipy 1.12 release,  `scipy.<numpy-func>` objects have been removed.
This PR, fix them by using directly the numpy function.
A test is also changed using a `np.sort_complex` to maintain deterministic behavior across numpy/scipy and python version.