### PR TITLE
Change default printing options in __main__ (tests).

### DIFF
--- a/eastereig/__main__.py
+++ b/eastereig/__main__.py
@@ -27,6 +27,7 @@ python3 -m eastereig
 """
 import doctest
 import sys
+import numpy as np
 from eastereig import _petscHere
 # immport the file containing the doctest
 from eastereig.examples import WGimpedance_numpy
@@ -38,6 +39,12 @@ from eastereig import ep
 from eastereig import lda_func
 from eastereig import eigSolvers
 from eastereig import fpoly
+
+# Numpy 2.0 change default printing options making doctest failing.
+# https://numpy.org/neps/nep-0051-scalar-representation.html
+# Use legacy mode for testing
+if np.lib.NumpyVersion(np.__version__) >= '2.0.0b1':
+    np.set_printoptions(legacy="1.25")
 
 if _petscHere:
     from eastereig.examples import WGimpedance_petsc

--- a/eastereig/fpoly/_fpoly.py
+++ b/eastereig/fpoly/_fpoly.py
@@ -69,22 +69,22 @@ def polyvalnd(nu, a):
     >>> a1 = np.random.rand(5)*(1+1j)
     >>> pvalf = polyvalnd(2.253+0.1j, a1)
     >>> pvalnp = polyval(2.253+0.1j, a1)
-    >>> abs(pvalf - pvalnp) < 1e-12
+    >>> abs(pvalf - pvalnp) < 1e-11
     True
     >>> a2 = np.random.rand(5, 5)*(1+1j)
     >>> pvalf = polyvalnd((2.253+0j, 1+1j), a2)
     >>> pvalnp = polyval2d(2.253+0j, 1+1j, a2)
-    >>> abs(pvalf - pvalnp) < 1e-12
+    >>> abs(pvalf - pvalnp) < 1e-11
     True
     >>> a3 = np.random.rand(5, 5, 5)*(1+1j)
     >>> pvalf =  polyvalnd((2.253, 1+1j, 0.1+2j), a3)
     >>> pvalnp = polyval3d(2.253, 1+1j, 0.1+2j, a3)
-    >>> abs(pvalf - pvalnp) < 1e-12
+    >>> abs(pvalf - pvalnp) < 1e-11
     True
     >>> a4 = np.random.rand(5, 5, 5, 5)*(1+1j)
     >>> pvalf =  polyvalnd((2.253, 1+1j, 0.1+2j, -0.8+0.2j), a4)
     >>> pvalnp = pu._valnd(polyval, a4, 2.253, 1+1j, 0.1+2j, -0.8+0.2j)
-    >>> abs(pvalf - pvalnp) < 1e-12
+    >>> abs(pvalf - pvalnp) < 1e-11
     True
     """
     d = len(a.shape)


### PR DESCRIPTION
Numpy 2.0 change the default printing options 
see https://numpy.org/neps/nep-0051-scalar-representation.html
This change crash doctests on scalars. For instance:

legacy:
```
>>> 2+np.int64(2)
4
```
New style:
```
>>> 2+np.int64(2)
np.int64(4)
```
This PR propose to use
```
np.set_printoptions(legacy="1.25")
```
Only in the test runner file, here `__main__.py`.

Perhaps we could change the format in doctest when numpy 2 will be more common.

I also change the tol in `_fpoly` doctest which was sometimes too strict.
