### PR TITLE
Remove explicit reference to umfpack in solver call

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ You'll need :
 * python packages: numpy, setuptools, wheel
 * pip (optional).
 * fortran compiler (optional)
+* install `scikit-umfpack` to improve `scipy.sparse` LU factorization performance (optional)
 Note that on ubuntu, you will need to use `pip3` instead of `pip` and `python3` instead of `python`. Please see the steps given in the continous integration script [workflows](.github/workflows/ci-ubuntu.yml).
 
 

--- a/eastereig/eig.py
+++ b/eastereig/eig.py
@@ -787,9 +787,9 @@ class ScipyspEig(AbstractEig):
 
             tic = time.time()  # init timer
             if n == 1:
-                # umfpack is not in scipy but need to be installed with scikit-umfpack
-                # if not present, scipy use superlu
-                sp.sparse.linalg.use_solver(useUmfpackbool=True)
+                # umfpack is not included in scipy but can be used with scikit-umfpack.
+                # umfpack is the default choice when available. If not, scipy uses superlu
+                # sp.sparse.linalg.use_solver(useUmfpack=True)
                 # compute the lu factor
                 lusolve = sp.sparse.linalg.factorized(Bord)
 


### PR DESCRIPTION
There was a  typo in `use_solver` argument masking problem with explicit dependence to `umfpack` LU solver in `eig.py`.
This PR solve the problem.
`umfpack` is now mentionned as a weak dependency in the README.