### PR TITLE
Update CI build matrix to exclude macOS 13

### DIFF
--- a/.github/workflows/ci-build-release.yml
+++ b/.github/workflows/ci-build-release.yml
@@ -14,8 +14,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macos-13 is an intel runner, macos-14 is apple silicon 
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        # macos-latest is ARM64-based, macos-26-intel is intel
+        # Hard to do cross compilation with fortran extension
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-26-intel]
     steps:
       - uses: actions/checkout@main
 
@@ -34,15 +35,18 @@ jobs:
           CIBW_ARCHS_WINDOWS: native
           # Set `use_fpoly=true` to build fortran extension
           CIBW_CONFIG_SETTINGS: setup-args="-Duse_fpoly=true"
-          # delocate-wheel ask to set the environment variable 'MACOSX_DEPLOYMENT_TARGET=13.0' to update minimum supported macOS for this wheel.
-          CIBW_ARCHS_MACOS: ${{ matrix.os == 'macos-14' && 'arm64' || 'x86_64' }}
+          # delocate-wheel used to ask to set the environment variable 'MACOSX_DEPLOYMENT_TARGET=13.0' to update minimum supported macOS for this wheel.
+          CIBW_ARCHS_MACOS: ${{ matrix.os == 'macos-latest' && 'arm64' || 'x86_64' }}
           CIBW_ENVIRONMENT_MACOS: >
-             CC=gcc-13 CXX=g++-13 FC=gfortran-13
-             MACOSX_DEPLOYMENT_TARGET=${{ matrix.os == 'macos-14' && '14.0' || '13.0' }}
+             CC=gcc-15 CXX=g++-15 FC=gfortran-15
+             MACOSX_DEPLOYMENT_TARGET='11.0'
           # CIBW_ENVIRONMENT: "MACOSX_DEPLOYMENT_TARGET=13.0"          
           CIBW_ENVIRONMENT_WINDOWS: CC=gcc CXX=g++ FC=gfortran
-#          CIBW_BEFORE_TEST: pip install pytest
-#          CIBW_TEST_COMMAND: "pytest --pyargs eastereig -v"
+          # Skip tests for any macOS wheel that is x86_64 since runner is arm
+          # Not used in practice since no cross compilation
+          # CIBW_TEST_SKIP: "*-macosx_x86_64"
+          # CIBW_BEFORE_TEST: pip install pytest
+          # CIBW_TEST_COMMAND: "pytest --pyargs eastereig -v"
           CIBW_TEST_COMMAND: "python -m eastereig.__main__"
 
       - uses: actions/upload-artifact@main

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
         EASTEREIG_USE_FPOLY: ['true', 'false']
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/eastereig/tests/test_charpol.py
+++ b/eastereig/tests/test_charpol.py
@@ -313,7 +313,7 @@ class Test_charpol_basics(unittest.TestCase):
         H = self.C.getdH()
         d_dH = H.eval_at(s[1::])
         # Check results
-        self.assertTrue(abs(d_ana-d_pcp_syl) < 1e-5)
+        self.assertTrue(abs(d_ana-d_pcp_syl) < 1e-4)
         self.assertTrue(abs(d_ana-d_dH) < 1e-5)
 
     def test_charpol_load_export(self):


### PR DESCRIPTION
Removed macOS 13 (now disable) and 14 to the profit of `macos-latest` (arm) and  `macos-26-intel` (x64_86) for the CI build matrix used to deploy release on pypi.

Hard to make work the cross compilation with fortran.
